### PR TITLE
Minor fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ def useApi(String dep) {
 
 processResources {
 	inputs.property "version", project.version
-	duplicatesStrategy = 'EXCLUDE'
+	duplicatesStrategy = 'WARN'
 
 	from(sourceSets.main.resources.srcDirs) {
 		include "fabric.mod.json"

--- a/src/main/java/ru/bclib/items/BaseAnvilItem.java
+++ b/src/main/java/ru/bclib/items/BaseAnvilItem.java
@@ -34,7 +34,9 @@ public class BaseAnvilItem extends BlockItem implements ItemModelProvider {
 		BlockState blockState = super.getPlacementState(blockPlaceContext);
 		ItemStack stack = blockPlaceContext.getItemInHand();
 		int destruction = stack.getOrCreateTag().getInt(DESTRUCTION);
-		blockState = blockState.setValue(BaseAnvilBlock.DESTRUCTION, destruction);
+		if (blockState != null) {
+			blockState = blockState.setValue(BaseAnvilBlock.DESTRUCTION, destruction);
+		}
 		return blockState;
 	}
 


### PR DESCRIPTION
- Trying to place an anvil on a Block where it is not allowed (i.e. on one of the obsidian pillars in the end) will result in a crash.

- Building with `EXCLUDE` includes the placeholder string `${version}` as the version number in the resulting lib.