### PR TITLE
Added Patch-Function for *level.dat *

### DIFF
--- a/src/main/java/ru/bclib/api/datafixer/Patch.java
+++ b/src/main/java/ru/bclib/api/datafixer/Patch.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class Patch {
+	
 	private static List<Patch> ALL = new ArrayList<>(10);
 	
 	/**
@@ -118,6 +119,19 @@ public abstract class Patch {
 	public Map<String, String> getIDReplacements() {
 		return new HashMap<String, String>();
 	}
+	
+	/**
+	 * Return a {@link PatchFunction} that is called with the content of <i>level.dat</i>.
+	 * <p>
+	 * The function needs to return {@code true}, if changes were made to the data.
+	 * If an error occurs, the method shoudl throw a {@link PatchDidiFailException}
+	 *
+	 * The default implementation of this method returns null.
+	 *
+	 * @return The returned function is called a {@code CompoundTag} that contains the
+	 * contents of <i>level.dat</i>
+	 */
+	public PatchFunction<CompoundTag, Boolean> getLevelDatPatcher() { return null; }
 	
 	/**
 	 * Generates ready to use data for all currently registered patches. The list of

--- a/src/main/java/ru/bclib/api/datafixer/PatchDidiFailException.java
+++ b/src/main/java/ru/bclib/api/datafixer/PatchDidiFailException.java
@@ -1,0 +1,10 @@
+package ru.bclib.api.datafixer;
+
+public class PatchDidiFailException extends Exception {
+	public PatchDidiFailException(){
+		super();
+	}
+	public PatchDidiFailException(Exception e){
+		super(e);
+	}
+}

--- a/src/main/java/ru/bclib/api/datafixer/PatchFunction.java
+++ b/src/main/java/ru/bclib/api/datafixer/PatchFunction.java
@@ -1,0 +1,6 @@
+package ru.bclib.api.datafixer;
+
+@FunctionalInterface
+public interface PatchFunction<T, R> {
+	R apply(T t) throws PatchDidiFailException;
+}


### PR DESCRIPTION
Adds callback functions (`getLevelDatPatcher`) that receive the content of the worlds **level.dat** file. The Method should throw a `PatchDidiFailException` if an error occurs.

```java
class Patcher_001 extends Patch {
	public Patcher_001() {
		super(BetterNether.MOD_ID, "5.2.1");
	}		
	
	@Override
	public PatchFunction<CompoundTag, Boolean> getLevelDatPatcher() {
		return this::patchLevelDat;
	}
	
	private boolean patchLevelDat(CompoundTag levelDat) 
        throws PatchDidiFailException {
		/* Do Something */
		return false; //Nothing changed
	}
}
```