### PR TITLE
ComplexMaterial 

### DIFF
--- a/src/main/java/ru/bclib/api/WorldDataAPI.java
+++ b/src/main/java/ru/bclib/api/WorldDataAPI.java
@@ -8,6 +8,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.world.level.storage.LevelStorageSource.LevelStorageAccess;
 import ru.bclib.BCLib;
+import ru.bclib.api.dataexchange.DataExchangeAPI;
 import ru.bclib.api.datafixer.DataFixerAPI;
 
 import java.io.File;
@@ -62,11 +63,14 @@ public class WorldDataAPI {
 	
 	/**
 	 * Register mod cache, world cache is located in world data folder.
+	 * <p>
+	 * Will also register the Mod for the {@link DataExchangeAPI} using {@link DataExchangeAPI#registerMod(String)}
 	 *
 	 * @param modID - {@link String} modID.
 	 */
 	public static void registerModCache(String modID) {
 		MODS.add(modID);
+		DataExchangeAPI.registerMod(modID);
 	}
 	
 	/**

--- a/src/main/java/ru/bclib/api/dataexchange/DataExchangeAPI.java
+++ b/src/main/java/ru/bclib/api/dataexchange/DataExchangeAPI.java
@@ -1,5 +1,6 @@
 package ru.bclib.api.dataexchange;
 
+import com.google.common.collect.Lists;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
@@ -7,9 +8,11 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.network.FriendlyByteBuf;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class DataExchangeAPI {
+	private final static List<String> MODS = Lists.newArrayList();
 	private static DataExchangeAPI instance;
 	private ConnectorServerside server;
 	private ConnectorClientside client;
@@ -44,6 +47,23 @@ public class DataExchangeAPI {
 		ServerPlayConnectionEvents.INIT.register(server::onPlayInit);
 		ServerPlayConnectionEvents.JOIN.register(server::onPlayReady);
 		ServerPlayConnectionEvents.DISCONNECT.register(server::onPlayDisconnect);
+	}
+	
+	/**
+	 * Register a mod to participate in the DataExchange.
+	 *
+	 * @param modID - {@link String} modID.
+	 */
+	public static void registerMod(String modID) {
+		MODS.add(modID);
+	}
+	
+	/**
+	 * Returns the IDs of all registered Mods.
+	 * @return List of modIDs
+	 */
+	public static List<String> registeredMods(){
+		return MODS;
 	}
 	
 	/**

--- a/src/main/java/ru/bclib/api/dataexchange/DataHandler.java
+++ b/src/main/java/ru/bclib/api/dataexchange/DataHandler.java
@@ -1,5 +1,7 @@
 package ru.bclib.api.dataexchange;
 
+import io.netty.buffer.ByteBufUtil;
+import io.netty.util.CharsetUtil;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
@@ -15,6 +17,8 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.StandardCharsets;
 
 public abstract class DataHandler {
 	private final boolean originatesOnServer;
@@ -103,5 +107,24 @@ public abstract class DataHandler {
 	@Override
 	public String toString() {
 		return "DataHandler{" + "originatesOnServer=" + originatesOnServer + ", identifier=" + identifier + '}';
+	}
+	
+	/**
+	 * Write a String to a buffer (Convenience Method)
+	 * @param buf The buffer to write to
+	 * @param s The String you want to write
+	 */
+	public static void writeString(FriendlyByteBuf buf, String s){
+		buf.writeByteArray(s.getBytes(StandardCharsets.UTF_8));
+	}
+	
+	/**
+	 * Read a string from a buffer (Convenience Method)
+	 * @param buf Thea buffer to read from
+	 * @return The received String
+	 */
+	public static String readString(FriendlyByteBuf buf){
+		byte[] data = buf.readByteArray();
+		return new String(data, StandardCharsets.UTF_8);
 	}
 }

--- a/src/main/java/ru/bclib/api/datafixer/DataFixerAPI.java
+++ b/src/main/java/ru/bclib/api/datafixer/DataFixerAPI.java
@@ -242,9 +242,6 @@ public class DataFixerAPI {
 	}
 
 	private static void runDataFixes(File dir, MigrationProfile profile, ProgressListener progress) {
-		System.out.println("RUNNING fixes");
-		if (dir!= null) return;
-		
 		State state = new State();
 		
 		List<File> regions = getAllRegions(dir, null);

--- a/src/main/java/ru/bclib/complexmaterials/ComplexMaterial.java
+++ b/src/main/java/ru/bclib/complexmaterials/ComplexMaterial.java
@@ -38,10 +38,12 @@ public abstract class ComplexMaterial {
 	
 	protected final String baseName;
 	protected final String modID;
+	protected final String receipGroupPrefix;
 	
-	public ComplexMaterial(String modID, String baseName) {
+	public ComplexMaterial(String modID, String baseName, String receipGroupPrefix) {
 		this.baseName = baseName;
 		this.modID = modID;
+		this.receipGroupPrefix = receipGroupPrefix;
 		MATERIALS.add(this);
 	}
 	

--- a/src/main/java/ru/bclib/complexmaterials/ComplexMaterial.java
+++ b/src/main/java/ru/bclib/complexmaterials/ComplexMaterial.java
@@ -251,6 +251,20 @@ public abstract class ComplexMaterial {
 	}
 	
 	/**
+	 * Replaces or Adds a default {@link BlockEntry} to this {@link ComplexMaterial}. Used to initiate blocks later.
+	 * <p>
+	 * If this {@link ComplexMaterial} does already contain an entry for the {@link ResourceLocation}, the entry will
+	 * be removed first.
+	 * @param entry {@link BlockEntry}
+	 */
+	protected void replaceOrAddBlockEntry(BlockEntry entry) {
+		int pos = defaultBlockEntries.indexOf(entry);
+		if (pos>=0) defaultBlockEntries.remove(entry);
+		
+		addBlockEntry(entry);
+	}
+	
+	/**
 	 * Adds a default {@link ItemEntry} to this {@link ComplexMaterial}. Used to initiate items later.
 	 * @param entry {@link ItemEntry}
 	 */

--- a/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
+++ b/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
@@ -67,8 +67,8 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 	public final MaterialColor planksColor;
 	public final MaterialColor woodColor;
 	
-	public WoodenComplexMaterial(String modID, String baseName, MaterialColor woodColor, MaterialColor planksColor) {
-		super(modID, baseName);
+	public WoodenComplexMaterial(String modID, String baseName, String receipGroupPrefix, MaterialColor woodColor, MaterialColor planksColor) {
+		super(modID, baseName, receipGroupPrefix);
 		this.planksColor = planksColor;
 		this.woodColor = woodColor;
 	}
@@ -217,7 +217,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setOutputCount(4)
 				.setList("#")
 				.addMaterial('#', log, bark, log_stripped, bark_stripped)
-				.setGroup("end_planks")
+				.setGroup(receipGroupPrefix +"_planks")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("stairs", (material, config, id) -> {
@@ -226,7 +226,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setOutputCount(4)
 				.setShape("#  ", "## ", "###")
 				.addMaterial('#', planks)
-				.setGroup("end_planks_stairs")
+				.setGroup(receipGroupPrefix +"_planks_stairs")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("slab", (material, config, id) -> {
@@ -235,7 +235,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setOutputCount(6)
 				.setShape("###")
 				.addMaterial('#', planks)
-				.setGroup("end_planks_slabs")
+				.setGroup(receipGroupPrefix +"_planks_slabs")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("fence", (material, config, id) -> {
@@ -245,7 +245,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setShape("#I#", "#I#")
 				.addMaterial('#', planks)
 				.addMaterial('I', Items.STICK)
-				.setGroup("end_planks_fences")
+				.setGroup(receipGroupPrefix +"_planks_fences")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("gate", (material, config, id) -> {
@@ -254,7 +254,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setShape("I#I", "I#I")
 				.addMaterial('#', planks)
 				.addMaterial('I', Items.STICK)
-				.setGroup("end_planks_gates")
+				.setGroup(receipGroupPrefix +"_planks_gates")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("button", (material, config, id) -> {
@@ -262,7 +262,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.checkConfig(config)
 				.setList("#")
 				.addMaterial('#', planks)
-				.setGroup("end_planks_buttons")
+				.setGroup(receipGroupPrefix +"_planks_buttons")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("pressure_plate", (material, config, id) -> {
@@ -270,7 +270,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.checkConfig(config)
 				.setShape("##")
 				.addMaterial('#', planks)
-				.setGroup("end_planks_plates")
+				.setGroup(receipGroupPrefix +"_planks_plates")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("trapdoor", (material, config, id) -> {
@@ -279,7 +279,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setOutputCount(2)
 				.setShape("###", "###")
 				.addMaterial('#', planks)
-				.setGroup("end_trapdoors")
+				.setGroup(receipGroupPrefix +"_trapdoors")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("door", (material, config, id) -> {
@@ -288,7 +288,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setOutputCount(3)
 				.setShape("##", "##", "##")
 				.addMaterial('#', planks)
-				.setGroup("end_doors")
+				.setGroup(receipGroupPrefix +"_doors")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("crafting_table", (material, config, id) -> {
@@ -296,7 +296,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.checkConfig(config)
 				.setShape("##", "##")
 				.addMaterial('#', planks)
-				.setGroup("end_tables")
+				.setGroup(receipGroupPrefix +"_tables")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("ladder", (material, config, id) -> {
@@ -306,7 +306,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setShape("I I", "I#I", "I I")
 				.addMaterial('#', planks)
 				.addMaterial('I', Items.STICK)
-				.setGroup("end_ladders")
+				.setGroup(receipGroupPrefix +"_ladders")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("sign", (material, config, id) -> {
@@ -316,7 +316,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setShape("###", "###", " I ")
 				.addMaterial('#', planks)
 				.addMaterial('I', Items.STICK)
-				.setGroup("end_signs")
+				.setGroup(receipGroupPrefix +"_signs")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("chest", (material, config, id) -> {
@@ -324,7 +324,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.checkConfig(config)
 				.setShape("###", "# #", "###")
 				.addMaterial('#', planks)
-				.setGroup("end_chests")
+				.setGroup(receipGroupPrefix +"_chests")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("barrel", (material, config, id) -> {
@@ -333,7 +333,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setShape("#S#", "# #", "#S#")
 				.addMaterial('#', planks)
 				.addMaterial('S', getBlock(BLOCK_SLAB))
-				.setGroup("end_barrels")
+				.setGroup(receipGroupPrefix +"_barrels")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("bookshelf", (material, config, id) -> {
@@ -342,7 +342,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.setShape("###", "PPP", "###")
 				.addMaterial('#', planks)
 				.addMaterial('P', Items.BOOK)
-				.setGroup("end_bookshelves")
+				.setGroup(receipGroupPrefix +"_bookshelves")
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("bark", (material, config, id) -> {

--- a/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
+++ b/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
@@ -374,7 +374,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 				.build();
 		}));
 		addRecipeEntry(new RecipeEntry("shulker", (material, config, id) -> {
-			GridRecipe.make(id, getBlock(BLOCK_COMPOSTER))
+			GridRecipe.make(id, Blocks.SHULKER_BOX)
 				.checkConfig(config)
 				.setShape("S", "#", "S")
 				.addMaterial('S', Items.SHULKER_SHELL)

--- a/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
+++ b/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
@@ -91,6 +91,12 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 	
 	@Override
 	protected void initDefault(FabricBlockSettings blockSettings, FabricItemSettings itemSettings) {
+		initBase(blockSettings, itemSettings);
+		initStorage(blockSettings, itemSettings);
+		initDecorations(blockSettings, itemSettings);
+	}
+	
+	protected void initBase(FabricBlockSettings blockSettings, FabricItemSettings itemSettings) {
 		Tag.Named<Block> tagBlockLog = getBlockTag(TAG_LOGS);
 		Tag.Named<Item> tagItemLog = getItemTag(TAG_LOGS);
 		
@@ -152,9 +158,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 			return new BaseDoorBlock(getBlock(BLOCK_PLANKS));
 		}).setBlockTags(BlockTags.DOORS, BlockTags.WOODEN_DOORS).setItemTags(ItemTags.DOORS, ItemTags.WOODEN_DOORS));
 		
-		addBlockEntry(new BlockEntry(BLOCK_CRAFTING_TABLE, (complexMaterial, settings) -> {
-			return new BaseCraftingTableBlock(getBlock(BLOCK_PLANKS));
-		}).setBlockTags(TagAPI.BLOCK_WORKBENCHES).setItemTags(TagAPI.ITEM_WORKBENCHES));
+		
 		addBlockEntry(new BlockEntry(BLOCK_LADDER, (complexMaterial, settings) -> {
 			return new BaseLadderBlock(getBlock(BLOCK_PLANKS));
 		}).setBlockTags(BlockTags.CLIMBABLE));
@@ -162,20 +166,27 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 			return new BaseSignBlock(getBlock(BLOCK_PLANKS));
 		}).setBlockTags(BlockTags.SIGNS).setItemTags(ItemTags.SIGNS));
 		
+		
+	}
+	
+	protected void initStorage(FabricBlockSettings blockSettings, FabricItemSettings itemSettings){
 		addBlockEntry(new BlockEntry(BLOCK_CHEST, (complexMaterial, settings) -> {
 			return new BaseChestBlock(getBlock(BLOCK_PLANKS));
 		}).setBlockTags(TagAPI.BLOCK_CHEST).setItemTags(TagAPI.ITEM_CHEST));
 		addBlockEntry(new BlockEntry(BLOCK_BARREL, (complexMaterial, settings) -> {
 			return new BaseBarrelBlock(getBlock(BLOCK_PLANKS));
 		}));
-		
+	}
+	
+	protected void initDecorations(FabricBlockSettings blockSettings, FabricItemSettings itemSettings){
+		addBlockEntry(new BlockEntry(BLOCK_CRAFTING_TABLE, (complexMaterial, settings) -> {
+			return new BaseCraftingTableBlock(getBlock(BLOCK_PLANKS));
+		}).setBlockTags(TagAPI.BLOCK_WORKBENCHES).setItemTags(TagAPI.ITEM_WORKBENCHES));
 		
 		addBlockEntry(new BlockEntry(BLOCK_BOOKSHELF, (complexMaterial, settings) -> {
 			return new BaseBookshelfBlock(getBlock(BLOCK_PLANKS));
 		}).setBlockTags(TagAPI.BLOCK_BOOKSHELVES));
-	
-	
-	
+		
 		addBlockEntry(new BlockEntry(BLOCK_COMPOSTER, (complexMaterial, settings) -> {
 			return new BaseComposterBlock(getBlock(BLOCK_PLANKS));
 		}));

--- a/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
+++ b/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
@@ -1,6 +1,5 @@
 package ru.bclib.complexmaterials;
 
-import com.google.common.collect.Lists;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
@@ -36,13 +35,8 @@ import ru.bclib.blocks.BaseWoodenButtonBlock;
 import ru.bclib.blocks.StripableBarkBlock;
 import ru.bclib.blocks.WoodenPressurePlateBlock;
 import ru.bclib.complexmaterials.entry.BlockEntry;
-import ru.bclib.complexmaterials.entry.ItemEntry;
 import ru.bclib.complexmaterials.entry.RecipeEntry;
-import ru.bclib.config.PathConfig;
 import ru.bclib.recipes.GridRecipe;
-
-import java.util.Arrays;
-import java.util.List;
 
 public class WoodenComplexMaterial extends ComplexMaterial {
 	public static final ResourceLocation MATERIAL_ID = BCLib.makeID("wooden_material");
@@ -97,14 +91,8 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 	
 	@Override
 	protected void initDefault(FabricBlockSettings blockSettings, FabricItemSettings itemSettings) {
-		initDefault(blockSettings, itemSettings, new String[0]);
-	}
-	
-	final protected void initDefault(FabricBlockSettings blockSettings, FabricItemSettings itemSettings, String[] excludedSuffixes) {
 		Tag.Named<Block> tagBlockLog = getBlockTag(TAG_LOGS);
 		Tag.Named<Item> tagItemLog = getItemTag(TAG_LOGS);
-		List<String> excl = Arrays.asList(excludedSuffixes);
-		
 		
 		addBlockEntry(
 			new BlockEntry(BLOCK_STRIPPED_LOG, (complexMaterial, settings) -> {
@@ -181,17 +169,16 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 			return new BaseBarrelBlock(getBlock(BLOCK_PLANKS));
 		}));
 		
-		if (!excl.contains(BLOCK_BOOKSHELF)) {
-			addBlockEntry(new BlockEntry(BLOCK_BOOKSHELF, (complexMaterial, settings) -> {
-				return new BaseBookshelfBlock(getBlock(BLOCK_PLANKS));
-			}).setBlockTags(TagAPI.BLOCK_BOOKSHELVES));
-		}
 		
-		if (!excl.contains(BLOCK_COMPOSTER)) {
-			addBlockEntry(new BlockEntry(BLOCK_COMPOSTER, (complexMaterial, settings) -> {
-				return new BaseComposterBlock(getBlock(BLOCK_PLANKS));
-			}));
-		}
+		addBlockEntry(new BlockEntry(BLOCK_BOOKSHELF, (complexMaterial, settings) -> {
+			return new BaseBookshelfBlock(getBlock(BLOCK_PLANKS));
+		}).setBlockTags(TagAPI.BLOCK_BOOKSHELVES));
+	
+	
+	
+		addBlockEntry(new BlockEntry(BLOCK_COMPOSTER, (complexMaterial, settings) -> {
+			return new BaseComposterBlock(getBlock(BLOCK_PLANKS));
+		}));
 	}
 	
 	@Override

--- a/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
+++ b/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
@@ -117,14 +117,14 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 		
 		addBlockEntry(
 			new BlockEntry(BLOCK_LOG, (complexMaterial, settings) -> {
-				return new BaseStripableLogBlock(woodColor, getBlock("stripped_log"));
+				return new BaseStripableLogBlock(woodColor, getBlock(BLOCK_STRIPPED_LOG));
 			})
 			.setBlockTags(BlockTags.LOGS, BlockTags.LOGS_THAT_BURN, tagBlockLog)
 			.setItemTags(ItemTags.LOGS, ItemTags.LOGS_THAT_BURN, tagItemLog)
 		);
 		addBlockEntry(
 			new BlockEntry(BLOCK_BARK, (complexMaterial, settings) -> {
-				return new StripableBarkBlock(woodColor, getBlock("stripped_bark"));
+				return new StripableBarkBlock(woodColor, getBlock(BLOCK_STRIPPED_BARK));
 			})
 			.setBlockTags(BlockTags.LOGS, BlockTags.LOGS_THAT_BURN, tagBlockLog)
 			.setItemTags(ItemTags.LOGS, ItemTags.LOGS_THAT_BURN, tagItemLog)

--- a/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
+++ b/src/main/java/ru/bclib/complexmaterials/WoodenComplexMaterial.java
@@ -96,7 +96,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 		initDecorations(blockSettings, itemSettings);
 	}
 	
-	protected void initBase(FabricBlockSettings blockSettings, FabricItemSettings itemSettings) {
+	final protected void initBase(FabricBlockSettings blockSettings, FabricItemSettings itemSettings) {
 		Tag.Named<Block> tagBlockLog = getBlockTag(TAG_LOGS);
 		Tag.Named<Item> tagItemLog = getItemTag(TAG_LOGS);
 		
@@ -169,7 +169,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 		
 	}
 	
-	protected void initStorage(FabricBlockSettings blockSettings, FabricItemSettings itemSettings){
+	final protected void initStorage(FabricBlockSettings blockSettings, FabricItemSettings itemSettings){
 		addBlockEntry(new BlockEntry(BLOCK_CHEST, (complexMaterial, settings) -> {
 			return new BaseChestBlock(getBlock(BLOCK_PLANKS));
 		}).setBlockTags(TagAPI.BLOCK_CHEST).setItemTags(TagAPI.ITEM_CHEST));
@@ -178,7 +178,7 @@ public class WoodenComplexMaterial extends ComplexMaterial {
 		}));
 	}
 	
-	protected void initDecorations(FabricBlockSettings blockSettings, FabricItemSettings itemSettings){
+	final protected void initDecorations(FabricBlockSettings blockSettings, FabricItemSettings itemSettings){
 		addBlockEntry(new BlockEntry(BLOCK_CRAFTING_TABLE, (complexMaterial, settings) -> {
 			return new BaseCraftingTableBlock(getBlock(BLOCK_PLANKS));
 		}).setBlockTags(TagAPI.BLOCK_WORKBENCHES).setItemTags(TagAPI.ITEM_WORKBENCHES));

--- a/src/main/java/ru/bclib/complexmaterials/entry/ComplexMaterialEntry.java
+++ b/src/main/java/ru/bclib/complexmaterials/entry/ComplexMaterialEntry.java
@@ -1,8 +1,12 @@
 package ru.bclib.complexmaterials.entry;
 
 import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
 
 public abstract class ComplexMaterialEntry {
+	@NotNull
 	private final String suffix;
 	
 	protected ComplexMaterialEntry(String suffix) {
@@ -19,5 +23,18 @@ public abstract class ComplexMaterialEntry {
 	
 	public String getSuffix() {
 		return suffix;
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ComplexMaterialEntry that = (ComplexMaterialEntry) o;
+		return suffix.equals(that.suffix);
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(suffix);
 	}
 }


### PR DESCRIPTION
- Adding back the `receipGroupName`. Without it, all receipts would end up with an **end_** prefix
- separated `initDefault` into three individual methods for base blocks, storage blocks and decoration blocks. This gives more control over material configurations without needing to copy&paste a lot of code
- Reenabled DataFixer API was still disabled for UI testing.