### PR TITLE
Always use the KubeJS workaround for recipe loading to improve mod compatibility

### DIFF
--- a/src/main/java/ru/bclib/mixin/common/MinecraftServerMixin.java
+++ b/src/main/java/ru/bclib/mixin/common/MinecraftServerMixin.java
@@ -3,7 +3,6 @@ package ru.bclib.mixin.common;
 import com.mojang.authlib.GameProfileRepository;
 import com.mojang.authlib.minecraft.MinecraftSessionService;
 import com.mojang.datafixers.DataFixer;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.core.RegistryAccess.RegistryHolder;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
@@ -34,45 +33,44 @@ import java.util.concurrent.CompletableFuture;
 
 @Mixin(MinecraftServer.class)
 public class MinecraftServerMixin {
-	@Shadow
-	private ServerResources resources;
-	
-	@Final
-	@Shadow
-	private Map<ResourceKey<Level>, ServerLevel> levels;
-	
-	@Final
-	@Shadow
-	protected WorldData worldData;
-	@Inject(method = "<init>*", at = @At("TAIL"))
-	private void bclib_onServerInit(Thread thread, RegistryHolder registryHolder, LevelStorageAccess levelStorageAccess, WorldData worldData, PackRepository packRepository, Proxy proxy, DataFixer dataFixer, ServerResources serverResources, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, GameProfileCache gameProfileCache, ChunkProgressListenerFactory chunkProgressListenerFactory, CallbackInfo ci){
-		DataExchangeAPI.prepareServerside();
-	}
+    @Shadow
+    private ServerResources resources;
 
-	@Inject(method="convertFromRegionFormatIfNeeded", at = @At("HEAD"))
-	private static void bclib_applyPatches(LevelStorageSource.LevelStorageAccess session, CallbackInfo ci){
+    @Final
+    @Shadow
+    private Map<ResourceKey<Level>, ServerLevel> levels;
+
+    @Final
+    @Shadow
+    protected WorldData worldData;
+
+    @Inject(method = "<init>*", at = @At("TAIL"))
+    private void bclib_onServerInit(Thread thread, RegistryHolder registryHolder, LevelStorageAccess levelStorageAccess, WorldData worldData, PackRepository packRepository, Proxy proxy, DataFixer dataFixer, ServerResources serverResources, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, GameProfileCache gameProfileCache, ChunkProgressListenerFactory chunkProgressListenerFactory, CallbackInfo ci) {
+        DataExchangeAPI.prepareServerside();
+    }
+
+    @Inject(method = "convertFromRegionFormatIfNeeded", at = @At("HEAD"))
+    private static void bclib_applyPatches(LevelStorageSource.LevelStorageAccess session, CallbackInfo ci) {
 		
 		/*File levelPath = session.getLevelPath(LevelResource.ROOT).toFile();
 		WorldDataAPI.load(new File(levelPath, "data"));
 		DataFixerAPI.fixData(levelPath, session.getLevelId());*/
-	}
+    }
 
 
-	@Inject(method = "reloadResources", at = @At(value = "RETURN"), cancellable = true)
-	private void bclib_reloadResources(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> info) {
-		bclib_injectRecipes();
-	}
-	
-	@Inject(method = "loadLevel", at = @At(value = "RETURN"), cancellable = true)
-	private void bclib_loadLevel(CallbackInfo info) {
-		bclib_injectRecipes();
-		BiomeAPI.initRegistry(MinecraftServer.class.cast(this));
-	}
-	
-	private void bclib_injectRecipes() {
-		if (FabricLoader.getInstance().isModLoaded("kubejs")) {
-			RecipeManagerAccessor accessor = (RecipeManagerAccessor) resources.getRecipeManager();
-			accessor.bclib_setRecipes(BCLRecipeManager.getMap(accessor.bclib_getRecipes()));
-		}
-	}
+    @Inject(method = "reloadResources", at = @At(value = "RETURN"), cancellable = true)
+    private void bclib_reloadResources(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> info) {
+        bclib_injectRecipes();
+    }
+
+    @Inject(method = "loadLevel", at = @At(value = "RETURN"), cancellable = true)
+    private void bclib_loadLevel(CallbackInfo info) {
+        bclib_injectRecipes();
+        BiomeAPI.initRegistry(MinecraftServer.class.cast(this));
+    }
+
+    private void bclib_injectRecipes() {
+        RecipeManagerAccessor accessor = (RecipeManagerAccessor) resources.getRecipeManager();
+        accessor.bclib_setRecipes(BCLRecipeManager.getMap(accessor.bclib_getRecipes()));
+    }
 }

--- a/src/main/java/ru/bclib/mixin/common/RecipeManagerMixin.java
+++ b/src/main/java/ru/bclib/mixin/common/RecipeManagerMixin.java
@@ -29,11 +29,6 @@ public abstract class RecipeManagerMixin {
 	@Shadow
 	private Map<RecipeType<?>, Map<ResourceLocation, Recipe<?>>> recipes;
 	
-	@Inject(method = "apply", at = @At(value = "RETURN"))
-	private void be_apply(Map<ResourceLocation, JsonElement> map, ResourceManager resourceManager, ProfilerFiller profiler, CallbackInfo info) {
-		recipes = BCLRecipeManager.getMap(recipes);
-	}
-	
 	@Shadow
 	private <C extends Container, T extends Recipe<C>> Map<ResourceLocation, Recipe<C>> byType(RecipeType<T> type) {
 		return null;


### PR DESCRIPTION
By always loading the recipes later it is ensured that other mods that might modify the recipe manager as well are done and don't interfere with BCLib or get disrupted by it. I personally needed this for a mod I'm working on and I believe other people might benefit from this too