### PR TITLE
Migrated BetterNether's PR BetterNether/pull/437 into BCLib

### DIFF
--- a/src/main/java/ru/bclib/mixin/common/LayerLightSectionStorageMixin.java
+++ b/src/main/java/ru/bclib/mixin/common/LayerLightSectionStorageMixin.java
@@ -1,0 +1,40 @@
+package ru.bclib.mixin.common;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.world.level.chunk.DataLayer;
+import net.minecraft.world.level.lighting.LayerLightSectionStorage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(LayerLightSectionStorage.class)
+public class LayerLightSectionStorageMixin {
+
+    @Shadow
+    protected DataLayer getDataLayer(long sectionPos, boolean cached) {
+        return null;
+    }
+
+    @Inject(method = "getStoredLevel", at = @At(value = "HEAD"), cancellable = true)
+    private void lightFix(long blockPos, CallbackInfoReturnable<Integer> info) {
+        try {
+            long m = SectionPos.blockToSection(blockPos);
+            DataLayer dataLayer = this.getDataLayer(m, true);
+            info.setReturnValue(
+                    dataLayer.get(
+                            SectionPos.sectionRelative(BlockPos.getX(blockPos)),
+                            SectionPos.sectionRelative(BlockPos.getY(blockPos)),
+                            SectionPos.sectionRelative(BlockPos.getZ(blockPos))
+                    )
+            );
+            info.cancel();
+        } catch (Exception e) {
+            info.setReturnValue(0);
+            info.cancel();
+        }
+    }
+
+}

--- a/src/main/resources/bclib.mixins.common.json
+++ b/src/main/resources/bclib.mixins.common.json
@@ -20,6 +20,7 @@
 		"MinecraftServerMixin",
 		"PistonBaseBlockMixin",
 		"WorldGenRegionMixin",
+		"LayerLightSectionStorageMixin",
 		"DimensionTypeMixin",
 		"RecipeManagerMixin",
 		"CraftingMenuMixin",


### PR DESCRIPTION
Moved BetterNether's PR [#437](https://github.com/paulevsGitch/BetterNether/pull/437) to BCLib, closes #43.