### PR TITLE
fixed potential decoding bug. 

### DIFF
--- a/src/main/java/ru/bclib/util/JsonFactory.java
+++ b/src/main/java/ru/bclib/util/JsonFactory.java
@@ -22,6 +22,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 public class JsonFactory {
 	public final static Gson GSON = new GsonBuilder().setPrettyPrinting()
@@ -69,7 +70,7 @@ public class JsonFactory {
 			Resource resource = manager.getResource(location);
 			if (resource != null) {
 				InputStream stream = resource.getInputStream();
-				InputStreamReader reader = new InputStreamReader(stream);
+				InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8);
 				obj = JsonFactory.GSON.fromJson(reader, JsonObject.class);
 				reader.close();
 				stream.close();


### PR DESCRIPTION
Fixes paulevsGitch/BCLib#117

The Bug Explanation :

The Class `BCLib/src/main/java/ru/bclib/util/JsonFactory`'s method

```java
public static JsonObject getJsonObject(ResourceLocation location)
```

calls

```java
public InputStreamReader(InputStream in)
```

which decodes `InputStream in` by computer system's default charset.

It means potential decoding bugs in some systems, like Chinese-environment Windows( which default charset is cp936 )

Besides, in Eden Ring mod, GuideBook' content depends on `resources/assets/edenring/lang/book/en_us.json` which includes lines like

```
            "§8● §lWorld of Eden",
```

and both `§` and `●` will become garbled.

So the solution is use 
```java
public InputStreamReader(InputStream in, Charset cs)
```

instead of the original.
